### PR TITLE
Drop Children from Game and Profiles when they are removed

### DIFF
--- a/barnacle-lib/src/repository/entities/game.rs
+++ b/barnacle-lib/src/repository/entities/game.rs
@@ -319,6 +319,8 @@ mod test {
         let repo = Repository::mock();
 
         let game = repo.add_game("Skyrim", DeployKind::CreationEngine).unwrap();
+        // TODO: Add tests asserting that profiles and mods have been recursively removed after the
+        // game is removed.
 
         assert_eq!(repo.games().unwrap().len(), 1);
 

--- a/barnacle-lib/src/repository/entities/game.rs
+++ b/barnacle-lib/src/repository/entities/game.rs
@@ -85,21 +85,30 @@ impl Game {
 
     pub(crate) fn remove(self) -> Result<()> {
         for p in self.profiles()? {
+            let profile_name = p.name().unwrap();
             p.remove()
                 .or_else(|err| match err {
                     Error::StaleEntityId => Ok(()), // if id is stale assume already removed
                     other => Err(other),
                 })
-                .expect("Unhandled profile removal error.");
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Failed to remove profile: {} during game cleanup",
+                        profile_name
+                    )
+                })
         }
 
         for m in self.mods()? {
+            let mod_name = m.name().unwrap();
             m.remove()
                 .or_else(|err| match err {
                     Error::StaleEntityId => Ok(()), // ditto
                     other => Err(other),
                 })
-                .expect("Unhandled mod removal error.");
+                .unwrap_or_else(|_| {
+                    panic!("Failed to remove mod: {} during game cleanup", mod_name)
+                })
         }
 
         let name = self.name()?;

--- a/barnacle-lib/src/repository/entities/game.rs
+++ b/barnacle-lib/src/repository/entities/game.rs
@@ -324,12 +324,13 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
     fn test_remove() {
         let repo = Repository::mock();
 
         let game = repo.add_game("Skyrim", DeployKind::CreationEngine).unwrap();
-        // TODO: Add tests asserting that profiles and mods have been recursively removed after the
-        // game is removed.
+        let profile = game.add_profile("test_profile_1").unwrap();
+        let _mod = game.add_mod("test_mod", None).unwrap();
 
         assert_eq!(repo.games().unwrap().len(), 1);
 
@@ -337,6 +338,9 @@ mod test {
 
         repo.remove_game(game).unwrap();
 
+        // attempt to remove already removed profile and mod entries (this should panic)
+        profile.remove().unwrap();
+        _mod.remove().unwrap();
         assert!(!dir.exists());
         assert_eq!(repo.games().unwrap().len(), 0);
     }

--- a/barnacle-lib/src/repository/entities/profile.rs
+++ b/barnacle-lib/src/repository/entities/profile.rs
@@ -243,6 +243,8 @@ mod test {
         let game = repo.add_game("Skyrim", DeployKind::CreationEngine).unwrap();
 
         let profile = game.add_profile("Test").unwrap();
+        // TODO: Add tests asserting that mod entries are recursively removed after the profile
+        // is removed
 
         assert_eq!(game.profiles().unwrap().len(), 1);
 

--- a/barnacle-lib/src/repository/entities/profile.rs
+++ b/barnacle-lib/src/repository/entities/profile.rs
@@ -149,13 +149,19 @@ impl Profile {
 
     pub(crate) fn remove(self) -> Result<()> {
         for entry in self.mod_entries()? {
+            let entry_id = entry.entry_id;
             entry
                 .remove()
                 .or_else(|err| match err {
                     Error::StaleEntityId => Ok(()), // if id is stale assume already removed
                     other => Err(other),
                 })
-                .expect("Unhandled mod entry removal.");
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "Failed to remove mod entry: {:?}: {} during profile cleanup",
+                        entry_id, err
+                    )
+                })
         }
 
         let name = self.name()?;

--- a/barnacle-lib/src/repository/entities/profile.rs
+++ b/barnacle-lib/src/repository/entities/profile.rs
@@ -244,13 +244,14 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
     fn test_remove() {
         let repo = Repository::mock();
         let game = repo.add_game("Skyrim", DeployKind::CreationEngine).unwrap();
+        let _mod = game.add_mod("test_mod", None).unwrap();
 
         let profile = game.add_profile("Test").unwrap();
-        // TODO: Add tests asserting that mod entries are recursively removed after the profile
-        // is removed
+        let mod_entry = profile.add_mod_entry(_mod).unwrap();
 
         assert_eq!(game.profiles().unwrap().len(), 1);
 
@@ -258,6 +259,8 @@ mod test {
 
         game.remove_profile(profile).unwrap();
 
+        // try removing already removed mod entry (this should panic)
+        mod_entry.remove().unwrap();
         assert!(!dir.exists());
         assert_eq!(game.profiles().unwrap().len(), 0);
     }


### PR DESCRIPTION
Couldn't find any references to `Tool` entities in Game.

But I'm pretty sure this will remove the relevant children from Game and Profile now when they are removed.

This also quietly passes on StaleEntityId and panics if another error is encountered.

Completes #45 