### PR TITLE
build: rollback rfd to 0.16.0 until regression is fixed

### DIFF
--- a/barnacle-gui/Cargo.toml
+++ b/barnacle-gui/Cargo.toml
@@ -16,7 +16,7 @@ iced = { version = "0.14.0", features = ["tokio", "svg", "advanced"] }
 iced_aw = { version = "0.13.0", features = ["spinner"], default-features = false }
 include_dir = "0.7.4"
 parking_lot = "0.12.5"
-rfd = "0.17.1"
+rfd = "0.16.0"
 serde = { version = "1.0.228", features = ["derive"] }
 strum = "0.27.2"
 sweeten = { git = "https://github.com/airstrike/sweeten" }


### PR DESCRIPTION
Roll back rfd dependency to version 0.16.0 in order to get file picker dialogs back.

While we wait on https://github.com/PolyMeilex/rfd/issues/305 to be resolved. Just sit at rfd version 0.16.0