### PR TITLE
Reimplement Nix Flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+watch_dir nix/
 use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,64 +1,6 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "naersk",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1752475459,
-        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "naersk": {
-      "inputs": {
-        "fenix": "fenix",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1752689277,
-        "narHash": "sha256-uldUBFkZe/E7qbvxa3mH1ItrWZyT6w1dBKJQF/3ZSsc=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "0e72363d0938b0208d6c646d10649164c43f4d64",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "master",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1756438964,
         "narHash": "sha256-yo473URkISSmBZeIE1o6Mf94VRSn5qFVFS9phb7l6eg=",
@@ -76,59 +18,7 @@
     },
     "root": {
       "inputs": {
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
-        "utils": "utils"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752428706,
-        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,69 +1,27 @@
 {
-  inputs = {
-    naersk.url = "github:nix-community/naersk/master";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    utils.url = "github:numtide/flake-utils";
-  };
-
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      systems = lib.platforms.linux; # Only support linux
+      forEachSystem = fn: lib.genAttrs systems (system: fn system nixpkgs.legacyPackages.${system});
+    in
     {
-      nixpkgs,
-      utils,
-      naersk,
-      ...
-    }:
-    utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        naersk-lib = callPackage naersk { };
+      packages = forEachSystem (
+        system: pkgs: rec {
+          barnacle = pkgs.callPackage ./nix/package.nix { };
+          default = barnacle;
+        }
+      );
 
-        inherit (pkgs)
-          mkShell
-          rustPlatform
-          callPackage
-          lib
-          ;
-      in
-      {
-        defaultPackage = naersk-lib.buildPackage ./.;
-        devShells.default = mkShell {
-          nativeBuildInputs = with pkgs; [
-            cargo
-            rustc
-            fuse-overlayfs
-            libarchive
-            openssl
-            pkg-config
-            mold-wrapped
-            cargo-tarpaulin
-            cargo-i18n
-          ];
-
-          packages = with pkgs; [
-            # Tools
-            bacon
-            diesel-cli
-            cargo-info
-            rustPackages.clippy
-            rustfmt
-            rust-analyzer
-          ];
-          env = {
-            RUST_SRC_PATH = rustPlatform.rustLibSrc;
-            RUSTFLAGS = "-C link-arg=-fuse-ld=mold"; # Use mold linker
-            LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:${
-              with pkgs;
-              lib.makeLibraryPath [
-                wayland
-                libxkbcommon
-                fontconfig
-                libGL
-                dbus
-              ]
-            }";
+      devShells = forEachSystem (
+        system: pkgs: {
+          default = import ./nix/shell.nix {
+            inherit pkgs;
+            inherit (self.packages.${system}) barnacle;
           };
-        };
-      }
-    );
+        }
+      );
+    };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  rustPlatform,
+
+  pkg-config,
+  makeWrapper,
+
+  fuse-overlayfs,
+  libarchive,
+  openssl,
+  cargo-tarpaulin,
+  cargo-i18n,
+
+  wayland,
+  libxkbcommon,
+  fontconfig,
+  libGL,
+  dbus,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "barnacle";
+  version = "0";
+
+  src = ../.;
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    fuse-overlayfs
+    libarchive
+    openssl
+    cargo-tarpaulin
+    cargo-i18n
+  ];
+  cargoHash = "sha256-6I0JKaeVJU5ROPToItwFwEO+UPr5OtFvY8ebJXKm0Yc=";
+
+  postInstall = ''
+    wrapProgram $out/bin/barnacle-gui \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libxkbcommon
+          fontconfig
+          libGL
+          dbus
+        ]
+      }
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/poperigby/barnacle";
+    description = "Fast, powerful mod manager for Linux";
+    mainProgram = "barnacle-gui";
+    license = licenses.gpl3;
+    maintainers = [
+      maintainers.kruziikrel13
+      maintainers.poperigby
+    ];
+  };
+})

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -54,7 +54,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/poperigby/barnacle";
     description = "Fast, powerful mod manager for Linux";
     mainProgram = "barnacle-gui";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
     maintainers = [
       maintainers.kruziikrel13
       maintainers.poperigby

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -29,11 +29,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   buildInputs = [
-    fuse-overlayfs
+    fuse-overlayfs # NOTE: Might only be necessary during runtime
     libarchive
     openssl
-    cargo-tarpaulin
-    cargo-i18n
   ];
   cargoHash = "sha256-6I0JKaeVJU5ROPToItwFwEO+UPr5OtFvY8ebJXKm0Yc=";
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,45 @@
+{
+  pkgs ? import <nixpkgs> { },
+  barnacle ? pkgs.callPackage ./package.nix { },
+}:
+let
+  inherit (pkgs) writeShellScriptBin lib;
+in
+pkgs.mkShell {
+  inputsFrom = [ barnacle ];
+
+  # Rust development tools
+  packages = with pkgs; [
+    bacon
+    diesel-cli
+    cargo-info
+    cargo-watch
+    rustPackages.clippy
+    rustfmt
+    rust-analyzer
+
+    # Useful shell Aliases as "packages"
+    (writeShellScriptBin "rmshare" ''
+      rm -rf ~/.local/share/barnacle
+    '')
+
+    (writeShellScriptBin "rmdb" ''
+      rm -rf ~/.local/state/barnacle
+    '')
+
+    (writeShellScriptBin "nuke" ''
+      rm -rf ~/.local/share/barnacle
+      rm -rf ~/.local/state/barnacle
+      rm -rf ~/.config/barnacle
+    '')
+  ];
+
+  # Ensure runtime dependencies are available
+  LD_LIBRARY_PATH = lib.makeLibraryPath [
+    pkgs.wayland
+    pkgs.libxkbcommon
+    pkgs.fontconfig
+    pkgs.libGL
+    pkgs.dbus
+  ];
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,12 +11,13 @@ pkgs.mkShell {
   # Rust development tools
   packages = with pkgs; [
     bacon
-    diesel-cli
     cargo-info
     cargo-watch
     rustPackages.clippy
     rustfmt
     rust-analyzer
+    cargo-tarpaulin
+    cargo-i18n
 
     # Useful shell Aliases as "packages"
     (writeShellScriptBin "rmshare" ''


### PR DESCRIPTION
- Reduce inputs to just nixpkgs
- Support exclusively linux
- Define barnacle in package.nix file
- Passes buildInputs defined in package.nix  to shell.nix ensuring parity
- Direnv watches nix/ directory now
- Wrap barnacle with runtime dependencies
- Added meta documentation to package
- Adds some useful shell scripts to the dev shell
  - rmshare
  - rmdb
  - nuke

> [!WARNING]
> This may break auto updates to cargo lock as the cargoHash will need to be updated in package.nix each time.

_The plus side to this, is that the package is even more "declarative" or reproducible. So we can always be certain that the hash in package.nix will result in a "working" build of barnacle._