### PR TITLE
nix: add lldb for debugging

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -18,6 +18,7 @@ pkgs.mkShell {
     rust-analyzer
     cargo-tarpaulin
     cargo-i18n
+    lldb
 
     # Useful shell Aliases as "packages"
     (writeShellScriptBin "rmshare" ''


### PR DESCRIPTION
LLDB can be used for debugging and stepping through code execution line by line. Very useful for finding issues in code you didn't write or finding crazy bugs.

My neovim config requires it be on the path... this adds it automatically!